### PR TITLE
protect email to be unique

### DIFF
--- a/migrations/006-uniqueEmail.sql
+++ b/migrations/006-uniqueEmail.sql
@@ -1,0 +1,1 @@
+ALTER TABLE users ADD UNIQUE (email);


### PR DESCRIPTION
When I was testing out authentication, I realized that I could create 2 accounts with the same email,  so I created this quick bug fix to remedy that.

**Instructions**: Once merged and pulled, run `psql trailer_park_db < migrations/006-uniqueEmail.sql` from the root folder of the project and then merge into your working branches.
